### PR TITLE
docs: restore ACM scaffold docs and boilerplate

### DIFF
--- a/.boilerplate/boilerplate.yml
+++ b/.boilerplate/boilerplate.yml
@@ -1,43 +1,28 @@
 ##
-# (c) 2025 - Cloud Ops Works LLC - https://cloudops.works/
-#            On GitHub: https://github.com/cloudopsworks
-#            Distributed Under Apache v2.0 License
+# (c) 2021-2026
+#     Cloud Ops Works LLC - https://cloudops.works/
+#     Find us on:
+#       GitHub: https://github.com/cloudopsworks
+#       WebSite: https://cloudops.works
+#     Distributed Under Apache v2.0 License
 #
+# Terragrunt Boilerplate Configuration
 variables:
   # Generic Boilerplate Variables Setup
-  - name: organization_name
-    order: 0
-    description: "Organization Name"
-    type: string
-    default: "Organization"
-  - name: organization_unit
-    order: 1
-    description: "Organization Unit"
-    type: string
-    default: "Unit"
-  - name: environment_name
-    order: 2
-    description: "Environment Name"
-    type: string
-    default: "DEV"
-  - name: environment_type
-    order: 3
-    description: "Environment Type"
-    type: string
-    default: "Testing"
-  - name: hub_spoke
-    order: 4
-    description: "Hub and Spoke architecture"
-    type: bool
-    default: false
   - name: is_hub
-    order: 5
+    order: 0
     description: "Is this a hub configuration?"
     type: bool
     default: false
   - name: tags
-    order: 6
+    order: 1
     description: "Tags"
     type: map
     default: {}
   # End - Generic Boilerplate Variables Setup
+
+hooks:
+  after:
+    - command: "git"
+      args: ["add", "."]
+      dir: "{{ outputFolder }}"

--- a/.boilerplate/inputs.yaml
+++ b/.boilerplate/inputs.yaml
@@ -1,18 +1,37 @@
 # Module configuration
-# Required variables
-{{- range .requiredVariables }}
-{{- if ne .Name "org"}}
-# Description {{ .Description }} , Type: {{ .Type }}
-{{ .Name }}: {{ .DefaultValuePlaceholder }}
-{{- end }}
+# AWS ACM certificate deployment inputs
 
-{{- end }}
-# Optional variables
-{{- range .optionalVariables }}
-{{- if ne .Name "is_hub" "spoke_def" "extra_args" }}
-# Description {{ .Description }} , Type: {{ .Type }}
-#{{ .Name }}: {{ .DefaultValue }}
-{{- end }}
+#name: ""                    # (Optional) Explicit ACM resource name. Overrides name_prefix when set. Default: ""
+#name_prefix: "managed-cert" # (Optional) Prefix used when name is empty. Default: "managed-cert"
+#create: true                 # (Optional) Set to false to skip all ACM and Route53 resources. Default: true
 
-{{- end }}
+certificate_type: "external" # (Optional) Certificate mode. Valid values: "external", "internal", "imported". Default: "external"
+domain_zone: "example.com"   # (Required for external/internal) Primary DNS zone used for the certificate. Example: "example.com"
+#domain_alias: "app"         # (Optional) Host label prepended to domain_zone. Example: "app" -> "app.example.com". Default: ""
+#domain_alternates:           # (Optional) Subject Alternative Names (SANs) for the certificate. Default: []
+#  - "*.example.com"
+#additional_domain_zones:     # (Optional) Extra Route53 zones used to validate SANs outside domain_zone. Default: []
+#  - "example.net"
 
+# Cross-account Route53 validation.
+#cross_account:
+#  enabled: false             # (Optional) Enable Route53 lookups/records in another AWS account. Default: false
+#  alias: "cross_account"    # (Optional) AWS provider alias generated in terragrunt.hcl. Default: "cross_account"
+#  region: "us-east-1"       # (Optional) Region for the cross-account AWS provider. Defaults to global-inputs.yaml default.region.
+#  sts_role_arn: "arn:aws:iam::111122223333:role/TerragruntCrossAccountRole" # (Optional) Role assumed for cross-account Route53 access.
+
+#private_zone: false          # (Optional) Set true when the validation zone is a private Route53 hosted zone. Default: false
+#external_dns_zone: false     # (Optional) Set true when DNS validation records are managed outside Route53. Default: false
+
+#imported_cert_secret_name: "" # (Required when certificate_type = "imported") Secrets Manager secret containing base64-encoded keys: key, public_key, cert_chain. Default: ""
+#internal_ca_arn: ""           # (Required when certificate_type = "internal") AWS Private CA ARN used to issue the certificate. Default: ""
+#early_renewal_days: 30         # (Optional) Days before expiry to renew internal certificates. Only used for internal certificates. Default: 0
+
+#options:                     # (Optional) ACM certificate options. Default: {}
+#  certificate_transparency: true # (Optional) Enable certificate transparency logging for eligible public certificates. Default: unset/provider default
+#  exportable: false             # (Optional) Make the certificate exportable when ACM supports it. Default: unset/provider default
+
+#alerts:                      # (Optional) Optional alert settings exposed by the module interface. Default: {}
+#  enabled: false             # (Optional) Enable alert metadata. Default: false
+#  priority: 3                # (Optional) Alert priority/severity. Default: 3
+#  sns_topic_arn: ""         # (Optional) SNS topic ARN recorded in the alert settings. Default: ""

--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -1,5 +1,4 @@
 locals {
-  {{- if .hub_spoke }}
   local_vars  = yamldecode(file("./inputs.yaml"))
   spoke_vars  = yamldecode(file(find_in_parent_folders("spoke-inputs.yaml")))
   region_vars = yamldecode(file(find_in_parent_folders("region-inputs.yaml")))
@@ -12,6 +11,12 @@ locals {
   env_tags    = jsondecode(file(find_in_parent_folders("env-tags.json")))
   global_tags = jsondecode(file(find_in_parent_folders("global-tags.json")))
 
+  # Cross Account variables
+  cross_account              = try(local.local_vars.cross_account.enabled, false)
+  cross_account_alias        = try(local.local_vars.cross_account.alias, "cross_account")
+  cross_account_region       = try(local.local_vars.cross_account.region, local.global_vars.default.region)
+  cross_account_sts_role_arn = try(local.local_vars.cross_account.sts_role_arn, local.global_vars.default.sts_role_arn)
+
   tags = merge(
     local.global_tags,
     local.env_tags,
@@ -19,21 +24,28 @@ locals {
     local.spoke_tags,
     local.local_tags
   )
-  {{- else }}
-  local_vars  = yamldecode(file("./inputs.yaml"))
-  global_vars = yamldecode(file(find_in_parent_folders("global-inputs.yaml")))
-  global_tags = jsondecode(file(find_in_parent_folders("global-tags.json")))
-  local_tags  = jsondecode(file("./local-tags.json"))
-
-  tags = merge(
-    local.global_tags,
-    local.local_tags
-  )
-  {{- end }}
 }
 
 include "root" {
-  path = find_in_parent_folders("root.hcl")
+  path = find_in_parent_folders("{{ .RootFileName }}")
+}
+
+# Generate cross-account AWS provider block when the module validates Route53 records in another account.
+generate "provider_l" {
+  path        = "provider.l.tf"
+  if_exists   = "overwrite_terragrunt"
+  if_disabled = "remove_terragrunt"
+  contents    = <<EOF_PROVIDER
+provider "aws" {
+  alias  = "${local.cross_account_alias}"
+  region = "${local.cross_account_region}"
+
+  assume_role {
+    role_arn     = "${local.cross_account_sts_role_arn}"
+    session_name = "terragrunt"
+  }
+}
+EOF_PROVIDER
 }
 
 terraform {
@@ -41,29 +53,19 @@ terraform {
 }
 
 inputs = {
-  # org = {
-  #   organization_name = local.env_vars.org.organization_name
-  #   organization_unit = local.env_vars.org.organization_unit
-  #   environment_name  = local.env_vars.org.environment_name
-  #   environment_type  = local.env_vars.org.environment_type
-  # }
-  org = local.env_vars.org
-  {{- if .hub_spoke }}
-  is_hub = {{ .is_hub }}
-  spoke_def = local.spoke_vars.spoke_def
-  {{- end}}
-  ## Required
+  is_hub    = {{ .is_hub }}
+  org       = local.env_vars.org
+  spoke_def = local.spoke_vars.spoke
   {{- range .requiredVariables }}
   {{- if ne .Name "org" }}
-  {{ .Name }} = try(local.local_vars.{{ .Name }}, {{ .DefaultValue }})
+  {{ .Name }} = local.local_vars.{{ .Name }}
   {{- end }}
   {{- end }}
-
-  ## Optional
   {{- range .optionalVariables }}
-  {{- if ne .Name "extra_tags" "is_hub" "spoke_def" "org" }}
+  {{- if not (eq .Name "extra_tags" "is_hub" "spoke_def" "org" "cross_account") }}
   {{ .Name }} = try(local.local_vars.{{ .Name }}, {{ .DefaultValue }})
   {{- end }}
   {{- end }}
-  extra_tags = local.tags
+  cross_account = local.cross_account
+  extra_tags    = local.tags
 }

--- a/README.md
+++ b/README.md
@@ -325,8 +325,8 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.43.0 |
-| <a name="provider_aws.cross_account"></a> [aws.cross\_account](#provider\_aws.cross\_account) | 6.43.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
+| <a name="provider_aws.cross_account"></a> [aws.cross\_account](#provider\_aws.cross\_account) | ~> 6.35 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@
 
 # Terraform ACM Certificate Management
 
+ [![Latest Release](https://img.shields.io/github/release/cloudopsworks/terraform-module-aws-acm-certificate.svg?style=for-the-badge)](https://github.com/cloudopsworks/terraform-module-aws-acm-certificate/releases/latest) [![Last Updated](https://img.shields.io/github/last-commit/cloudopsworks/terraform-module-aws-acm-certificate.svg?style=for-the-badge)](https://github.com/cloudopsworks/terraform-module-aws-acm-certificate/commits)
 
 
-
-AWS Certificate Manager (ACM) Terraform module for comprehensive SSL/TLS certificate management supporting external (DNS validated), imported (from existing certificates), and internal (Private CA) certificate types. Features include cross-account certificate management, local and external DNS validation, automatic validation record creation, and configurable certificate options for transparency and exportability.
+AWS Certificate Manager (ACM) Terraform module for issuing, importing, and validating
+SSL/TLS certificates with Route53-aware DNS automation. The module supports public
+certificates with local or cross-account DNS validation, imported certificates sourced
+from AWS Secrets Manager, and private certificates issued from AWS Private CA.
 
 
 ---
@@ -45,21 +48,18 @@ We have [*lots of terraform modules*][terraform_modules] that are Open Source an
 
 ## Introduction
 
-This Terraform module provides a comprehensive solution for managing SSL/TLS certificates in AWS Certificate Manager (ACM). The module offers:
+This module provides a single ACM workflow that fits the most common certificate
+delivery patterns used in Cloud Ops Works Terragrunt stacks:
 
-Certificate Types:
-- External certificates with automated DNS validation
-- Imported certificates from external sources (using AWS Secrets Manager)
-- Internal certificates using AWS Private Certificate Authority
-
-Key Features:
-- Cross-account certificate management with dedicated provider configuration
-- Automatic DNS validation record creation in Route53
-- Support for both local and external DNS zones
-- Multiple domain validation with SAN support
-- Configurable certificate transparency logging
-- Certificate exportability options
-- Early renewal configuration for internal certificates
+- **External ACM certificates** with automatic DNS validation record management.
+- **Cross-account Route53 validation** by generating an aliased provider block in the
+  scaffolded Terragrunt layer.
+- **Imported ACM certificates** loaded from AWS Secrets Manager secrets.
+- **Internal ACM certificates** issued from AWS Private Certificate Authority with
+  optional early renewal windows.
+- **Multi-domain coverage** through SAN entries and additional validation zones.
+- **Terragrunt-friendly scaffolding** with generated `terragrunt.hcl`, `inputs.yaml`,
+  and `local-tags.json` files.
 
 ## Usage
 
@@ -68,244 +68,236 @@ Key Features:
 Instead pin to the release tag (e.g. `?ref=vX.Y.Z`) of one of our [latest releases](https://github.com/cloudopsworks/terraform-module-aws-acm-certificate/releases).
 
 
-Module Configuration Variables:
+### Terragrunt Scaffolding Workflow
 
-```yaml
-create:
-  description: "Flag to control resource creation"
-  type: bool
-  default: true
+Use Terragrunt scaffold to bootstrap a deployment directory from this module's
+`.boilerplate/` template.
 
-certificate_type:
-  description: "Type of certificate (external/imported/internal)"
-  type: string
-  required: true
+```sh
+# 1. Create and enter the target deployment directory
+mkdir -p <environment>/<region>/<spoke>/acm-certificate
+cd <environment>/<region>/<spoke>/acm-certificate
 
-domain_zone:
-  description: "Main domain zone for the certificate"
-  type: string
-  required: true
+# 2. Scaffold the module (do NOT use --working-dir)
+terragrunt scaffold github.com/cloudopsworks/terraform-module-aws-acm-certificate
 
-domain_alias:
-  description: "Subdomain prefix for the certificate"
-  type: string
-  default: ""
+# 3. Edit inputs.yaml with deployment-specific values
+vi inputs.yaml
 
-domain_alternates:
-  description: "List of Subject Alternative Names (SANs)"
-  type: list(string)
-  default: []
-
-cross_account:
-  description: "Enable cross-account certificate management"
-  type: bool
-  default: false
-
-external_dns_zone:
-  description: "Flag for external DNS zone management"
-  type: bool
-  default: false
-
-imported_cert_secret_name:
-  description: "AWS Secrets Manager secret name for imported certificate"
-  type: string
-  default: ""
-
-internal_ca_arn:
-  description: "ARN of Private Certificate Authority for internal certificates"
-  type: string
-  default: ""
-
-early_renewal_days:
-  description: "Number of days before certificate expiry to trigger renewal"
-  type: number
-  default: 0
-
-options:
-  description: "Certificate configuration options"
-  type: map
-  default: {}
-  fields:
-    certificate_transparency:
-      description: "Enable/disable certificate transparency logging"
-      type: bool
-    exportable:
-      description: "Enable/disable certificate export capability"
-      type: bool
+# 4. Apply
+terragrunt apply
 ```
 
-Terragrunt Configuration:
+### Generated `inputs.yaml`
+
+After scaffolding, Terragrunt generates an `inputs.yaml` file with the module-specific
+inputs below:
+
+```yaml
+#name: ""                    # (Optional) Explicit ACM resource name. Overrides name_prefix when set. Default: ""
+#name_prefix: "managed-cert" # (Optional) Prefix used when name is empty. Default: "managed-cert"
+#create: true                 # (Optional) Set to false to skip all ACM and Route53 resources. Default: true
+
+certificate_type: "external" # (Optional) Certificate mode. Valid values: "external", "internal", "imported". Default: "external"
+domain_zone: "example.com"   # (Required for external/internal) Primary DNS zone used for the certificate. Example: "example.com"
+#domain_alias: "app"         # (Optional) Host label prepended to domain_zone. Example: "app" -> "app.example.com". Default: ""
+#domain_alternates:           # (Optional) Subject Alternative Names (SANs) for the certificate. Default: []
+#  - "*.example.com"
+#additional_domain_zones:     # (Optional) Extra Route53 zones used to validate SANs outside domain_zone. Default: []
+#  - "example.net"
+
+# Cross-account Route53 validation.
+#cross_account:
+#  enabled: false             # (Optional) Enable Route53 lookups/records in another AWS account. Default: false
+#  alias: "cross_account"    # (Optional) AWS provider alias generated in terragrunt.hcl. Default: "cross_account"
+#  region: "us-east-1"       # (Optional) Region for the cross-account AWS provider. Defaults to global-inputs.yaml default.region.
+#  sts_role_arn: "arn:aws:iam::111122223333:role/TerragruntCrossAccountRole" # (Optional) Role assumed for cross-account Route53 access.
+
+#private_zone: false          # (Optional) Set true when the validation zone is a private Route53 hosted zone. Default: false
+#external_dns_zone: false     # (Optional) Set true when DNS validation records are managed outside Route53. Default: false
+
+#imported_cert_secret_name: "" # (Required when certificate_type = "imported") Secrets Manager secret containing base64-encoded keys: key, public_key, cert_chain. Default: ""
+#internal_ca_arn: ""           # (Required when certificate_type = "internal") AWS Private CA ARN used to issue the certificate. Default: ""
+#early_renewal_days: 30         # (Optional) Days before expiry to renew internal certificates. Only used for internal certificates. Default: 0
+
+#options:                     # (Optional) ACM certificate options. Default: {}
+#  certificate_transparency: true # (Optional) Enable certificate transparency logging for eligible public certificates. Default: unset/provider default
+#  exportable: false             # (Optional) Make the certificate exportable when ACM supports it. Default: unset/provider default
+
+#alerts:                      # (Optional) Optional alert settings exposed by the module interface. Default: {}
+#  enabled: false             # (Optional) Enable alert metadata. Default: false
+#  priority: 3                # (Optional) Alert priority/severity. Default: 3
+#  sns_topic_arn: ""         # (Optional) SNS topic ARN recorded in the alert settings. Default: ""
+```
+
+### Generated `terragrunt.hcl`
+
+The scaffold also renders a `terragrunt.hcl` that loads `inputs.yaml`, derives the
+cross-account provider settings, and maps the file into module inputs:
+
 ```hcl
-include {
-  path = find_in_parent_folders()
+locals {
+  local_vars  = yamldecode(file("./inputs.yaml"))
+  spoke_vars  = yamldecode(file(find_in_parent_folders("spoke-inputs.yaml")))
+  region_vars = yamldecode(file(find_in_parent_folders("region-inputs.yaml")))
+  env_vars    = yamldecode(file(find_in_parent_folders("env-inputs.yaml")))
+  global_vars = yamldecode(file(find_in_parent_folders("global-inputs.yaml")))
+
+  local_tags  = jsondecode(file("./local-tags.json"))
+  spoke_tags  = jsondecode(file(find_in_parent_folders("spoke-tags.json")))
+  region_tags = jsondecode(file(find_in_parent_folders("region-tags.json")))
+  env_tags    = jsondecode(file(find_in_parent_folders("env-tags.json")))
+  global_tags = jsondecode(file(find_in_parent_folders("global-tags.json")))
+
+  cross_account              = try(local.local_vars.cross_account.enabled, false)
+  cross_account_alias        = try(local.local_vars.cross_account.alias, "cross_account")
+  cross_account_region       = try(local.local_vars.cross_account.region, local.global_vars.default.region)
+  cross_account_sts_role_arn = try(local.local_vars.cross_account.sts_role_arn, local.global_vars.default.sts_role_arn)
+
+  tags = merge(
+    local.global_tags,
+    local.env_tags,
+    local.region_tags,
+    local.spoke_tags,
+    local.local_tags
+  )
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+generate "provider_l" {
+  path        = "provider.l.tf"
+  if_exists   = "overwrite_terragrunt"
+  if_disabled = "remove_terragrunt"
+  contents    = <<EOF_PROVIDER
+provider "aws" {
+  alias  = "${local.cross_account_alias}"
+  region = "${local.cross_account_region}"
+
+  assume_role {
+    role_arn     = "${local.cross_account_sts_role_arn}"
+    session_name = "terragrunt"
+  }
+}
+EOF_PROVIDER
 }
 
 terraform {
-  source = "git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git?ref=v1.0.0"
-}
-
-
-# Generate global cross_account provider block
-generate "provider_l" {
-  path = "provider.l.tf"
-  #   disable     = !local.cross_account
-  if_exists   = "overwrite_terragrunt"
-  if_disabled = "remove_terragrunt"
-  contents    = <<EOF
-  provider "aws" {
-    alias = "${local.cross_account_alias}"
-    region = "${local.cross_account_region}"
-    assume_role {
-      role_arn     = "${local.cross_account_sts_role_arn}"
-      session_name = "terragrunt"
-    }
-  }
-  EOF
+  source = "git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git?ref=v1.3.5"
 }
 
 inputs = {
-  certificate_type = "external"
-  domain_zone     = "example.com"
-  domain_alias    = "app"
-  domain_alternates = ["*.app.example.com"]
+  is_hub    = false
+  org       = local.env_vars.org
+  spoke_def = local.spoke_vars.spoke
 
-  options = {
-    certificate_transparency = true
-    exportable = false
-  }
+  certificate_type        = local.local_vars.certificate_type
+  domain_zone             = local.local_vars.domain_zone
+  domain_alias            = try(local.local_vars.domain_alias, "")
+  domain_alternates       = try(local.local_vars.domain_alternates, [])
+  additional_domain_zones = try(local.local_vars.additional_domain_zones, [])
+  create                  = try(local.local_vars.create, true)
+  external_dns_zone       = try(local.local_vars.external_dns_zone, false)
+  imported_cert_secret_name = try(local.local_vars.imported_cert_secret_name, "")
+  internal_ca_arn         = try(local.local_vars.internal_ca_arn, "")
+  early_renewal_days      = try(local.local_vars.early_renewal_days, 0)
+  name                    = try(local.local_vars.name, "")
+  name_prefix             = try(local.local_vars.name_prefix, "managed-cert")
+  options                 = try(local.local_vars.options, {})
+  alerts                  = try(local.local_vars.alerts, {})
+  private_zone            = try(local.local_vars.private_zone, false)
+
+  cross_account = local.cross_account
+  extra_tags    = local.tags
 }
 ```
 
 ## Quick Start
 
-1. Create a Terragrunt configuration file (terragrunt.hcl):
-   ```hcl
-   include {
-     path = find_in_parent_folders()
-   }
-
-   terraform {
-     source = "git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git?ref=v1.0.0"
-   }
-
-   inputs = {
-     certificate_type = "external"
-     domain_zone     = "example.com"
-     domain_alias    = "app"
-     domain_alternates = ["*.app.example.com"]
-
-     options = {
-       certificate_transparency = true
-       exportable = false
-     }
-   }
+1. Create a Terragrunt deployment directory and scaffold the module:
+   ```sh
+   mkdir -p prod/us-east-1/spoke-001/acm-certificate
+   cd prod/us-east-1/spoke-001/acm-certificate
+   terragrunt scaffold github.com/cloudopsworks/terraform-module-aws-acm-certificate
    ```
 
-2. For cross-account setup, configure the provider (provider.tf):
-   ```hcl
-   provider "aws" {
-     alias = "cross_account"
-     assume_role {
-       role_arn = "arn:aws:iam::ACCOUNT_ID:role/CrossAccountRole"
-     }
-   }
-   ```
+2. Edit `inputs.yaml` for your certificate type:
+   - Set `certificate_type` to `external`, `imported`, or `internal`
+   - Set `domain_zone` and optional `domain_alias` / `domain_alternates`
+   - For `imported`, set `imported_cert_secret_name`
+   - For `internal`, set `internal_ca_arn` and optional `early_renewal_days`
+   - For cross-account DNS validation, define the `cross_account` object
 
-3. Initialize Terragrunt:
-   ```bash
-   terragrunt init
-   ```
-
-4. Review the planned changes:
-   ```bash
+3. Review the plan:
+   ```sh
    terragrunt plan
    ```
 
-5. Apply the configuration:
-   ```bash
+4. Apply the configuration:
+   ```sh
    terragrunt apply
    ```
 
-6. Monitor certificate status:
-   - For external certificates: Check Route53 for validation records
-   - For imported certificates: Verify secret in Secrets Manager
-   - For internal certificates: Monitor Private CA for issuance
+5. Monitor validation/issuance:
+   - External certificates: ensure DNS validation records propagate
+   - Imported certificates: verify the Secrets Manager payload contains `key`, `public_key`, and `cert_chain`
+   - Internal certificates: verify the referenced Private CA is active and authorized
 
 
 ## Examples
 
-External Certificate with Local DNS Validation:
-```hcl
-module "external_certificate" {
-  source = "cloudopsworks/terraform-module-aws-acm-certificate"
+### External certificate with Route53 validation
 
-  certificate_type = "external"
-  domain_zone     = "example.com"
-  domain_alias    = "api"
-  domain_alternates = ["*.api.example.com"]
-  cross_account   = false
-  external_dns_zone = false
-
-  options = {
-    certificate_transparency = true
-    exportable = false
-  }
-}
+```yaml
+certificate_type: "external"
+domain_zone: "example.com"
+domain_alias: "app"
+domain_alternates:
+  - "*.app.example.com"
+options:
+  certificate_transparency: true
+  exportable: false
 ```
 
-Cross-Account Certificate:
-```hcl
-module "cross_account_cert" {
-  source = "cloudopsworks/terraform-module-aws-acm-certificate"
-  providers = {
-    aws.cross_account = aws.dns_account
-  }
+### Cross-account Route53 validation
 
-  certificate_type = "external"
-  domain_zone     = "example.com"
-  domain_alias    = "app"
-  cross_account   = true
-  domain_alternates = ["api.example.com"]
-
-  options = {
-    certificate_transparency = true
-    exportable = true
-  }
-}
+```yaml
+certificate_type: "external"
+domain_zone: "example.com"
+domain_alias: "api"
+cross_account:
+  enabled: true
+  alias: "dns_account"
+  region: "us-east-1"
+  sts_role_arn: "arn:aws:iam::111122223333:role/TerragruntCrossAccountRole"
+domain_alternates:
+  - "api.example.net"
+additional_domain_zones:
+  - "example.net"
 ```
 
-Imported Certificate from Secrets Manager:
-```hcl
-module "imported_cert" {
-  source = "cloudopsworks/terraform-module-aws-acm-certificate"
+### Imported certificate from Secrets Manager
 
-  certificate_type = "imported"
-  domain_zone     = "example.com"
-  imported_cert_secret_name = "imported/wildcard-cert"
-
-  options = {
-    certificate_transparency = false
-    exportable = true
-  }
-}
+```yaml
+certificate_type: "imported"
+domain_zone: "example.com"
+imported_cert_secret_name: "/platform/shared/acm/wildcard-example-com"
+options:
+  exportable: true
 ```
 
-Internal Certificate with Private CA:
-```hcl
-module "internal_cert" {
-  source = "cloudopsworks/terraform-module-aws-acm-certificate"
+### Internal certificate from AWS Private CA
 
-  certificate_type = "internal"
-  domain_zone     = "internal.example.com"
-  domain_alias    = "service"
-  internal_ca_arn = "arn:aws:acm-pca:region:account:certificate-authority/12345678-1234-1234-1234-123456789012"
-  early_renewal_days = 30
-
-  options = {
-    certificate_transparency = false
-    exportable = true
-  }
-}
+```yaml
+certificate_type: "internal"
+domain_zone: "internal.example.com"
+domain_alias: "service"
+internal_ca_arn: "arn:aws:acm-pca:us-east-1:111122223333:certificate-authority/12345678-1234-1234-1234-123456789012"
+early_renewal_days: 30
+options:
+  exportable: true
 ```
 
 
@@ -333,8 +325,8 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
-| <a name="provider_aws.cross_account"></a> [aws.cross\_account](#provider\_aws.cross\_account) | ~> 6.35 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.43.0 |
+| <a name="provider_aws.cross_account"></a> [aws.cross\_account](#provider\_aws.cross\_account) | 6.43.0 |
 
 ## Modules
 
@@ -391,11 +383,11 @@ Available targets:
 
 | Name | Description |
 |------|-------------|
-| <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | n/a |
-| <a name="output_acm_certificate_expire_date"></a> [acm\_certificate\_expire\_date](#output\_acm\_certificate\_expire\_date) | n/a |
-| <a name="output_acm_certificate_renewal_elegibility"></a> [acm\_certificate\_renewal\_elegibility](#output\_acm\_certificate\_renewal\_elegibility) | n/a |
-| <a name="output_acm_certificate_status"></a> [acm\_certificate\_status](#output\_acm\_certificate\_status) | n/a |
-| <a name="output_acm_certificate_validation_options"></a> [acm\_certificate\_validation\_options](#output\_acm\_certificate\_validation\_options) | n/a |
+| <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | ARN of the ACM certificate created or imported by this module. |
+| <a name="output_acm_certificate_expire_date"></a> [acm\_certificate\_expire\_date](#output\_acm\_certificate\_expire\_date) | Certificate expiration timestamp reported by ACM. |
+| <a name="output_acm_certificate_renewal_elegibility"></a> [acm\_certificate\_renewal\_elegibility](#output\_acm\_certificate\_renewal\_elegibility) | ACM renewal eligibility state for the managed certificate. |
+| <a name="output_acm_certificate_status"></a> [acm\_certificate\_status](#output\_acm\_certificate\_status) | Current ACM certificate status returned by AWS. |
+| <a name="output_acm_certificate_validation_options"></a> [acm\_certificate\_validation\_options](#output\_acm\_certificate\_validation\_options) | Domain validation records to publish when using external DNS automation for public certificates. |
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -1,6 +1,14 @@
 name: Terraform ACM Certificate Management
 #logo: logo/logo.jpg
 
+badges:
+  - name: Latest Release
+    image: https://img.shields.io/github/release/cloudopsworks/terraform-module-aws-acm-certificate.svg?style=for-the-badge
+    url: https://github.com/cloudopsworks/terraform-module-aws-acm-certificate/releases/latest
+  - name: Last Updated
+    image: https://img.shields.io/github/last-commit/cloudopsworks/terraform-module-aws-acm-certificate.svg?style=for-the-badge
+    url: https://github.com/cloudopsworks/terraform-module-aws-acm-certificate/commits
+
 license: "APACHE2"
 
 copyrights:
@@ -11,266 +19,254 @@ copyrights:
 github_repo: cloudopsworks/terraform-module-aws-acm-certificate
 
 description: |-
-  AWS Certificate Manager (ACM) Terraform module for comprehensive SSL/TLS certificate management supporting external (DNS validated), imported (from existing certificates), and internal (Private CA) certificate types. Features include cross-account certificate management, local and external DNS validation, automatic validation record creation, and configurable certificate options for transparency and exportability.
+  AWS Certificate Manager (ACM) Terraform module for issuing, importing, and validating
+  SSL/TLS certificates with Route53-aware DNS automation. The module supports public
+  certificates with local or cross-account DNS validation, imported certificates sourced
+  from AWS Secrets Manager, and private certificates issued from AWS Private CA.
 
-# Introduction to the project
 introduction: |-
-  This Terraform module provides a comprehensive solution for managing SSL/TLS certificates in AWS Certificate Manager (ACM). The module offers:
+  This module provides a single ACM workflow that fits the most common certificate
+  delivery patterns used in Cloud Ops Works Terragrunt stacks:
 
-  Certificate Types:
-  - External certificates with automated DNS validation
-  - Imported certificates from external sources (using AWS Secrets Manager)
-  - Internal certificates using AWS Private Certificate Authority
+  - **External ACM certificates** with automatic DNS validation record management.
+  - **Cross-account Route53 validation** by generating an aliased provider block in the
+    scaffolded Terragrunt layer.
+  - **Imported ACM certificates** loaded from AWS Secrets Manager secrets.
+  - **Internal ACM certificates** issued from AWS Private Certificate Authority with
+    optional early renewal windows.
+  - **Multi-domain coverage** through SAN entries and additional validation zones.
+  - **Terragrunt-friendly scaffolding** with generated `terragrunt.hcl`, `inputs.yaml`,
+    and `local-tags.json` files.
 
-  Key Features:
-  - Cross-account certificate management with dedicated provider configuration
-  - Automatic DNS validation record creation in Route53
-  - Support for both local and external DNS zones
-  - Multiple domain validation with SAN support
-  - Configurable certificate transparency logging
-  - Certificate exportability options
-  - Early renewal configuration for internal certificates
-
-# How to use this project
 usage: |-
-  Module Configuration Variables:
+  ### Terragrunt Scaffolding Workflow
 
-  ```yaml
-  create:
-    description: "Flag to control resource creation"
-    type: bool
-    default: true
+  Use Terragrunt scaffold to bootstrap a deployment directory from this module's
+  `.boilerplate/` template.
 
-  certificate_type:
-    description: "Type of certificate (external/imported/internal)"
-    type: string
-    required: true
+  ```sh
+  # 1. Create and enter the target deployment directory
+  mkdir -p <environment>/<region>/<spoke>/acm-certificate
+  cd <environment>/<region>/<spoke>/acm-certificate
 
-  domain_zone:
-    description: "Main domain zone for the certificate"
-    type: string
-    required: true
+  # 2. Scaffold the module (do NOT use --working-dir)
+  terragrunt scaffold github.com/cloudopsworks/terraform-module-aws-acm-certificate
 
-  domain_alias:
-    description: "Subdomain prefix for the certificate"
-    type: string
-    default: ""
+  # 3. Edit inputs.yaml with deployment-specific values
+  vi inputs.yaml
 
-  domain_alternates:
-    description: "List of Subject Alternative Names (SANs)"
-    type: list(string)
-    default: []
-
-  cross_account:
-    description: "Enable cross-account certificate management"
-    type: bool
-    default: false
-
-  external_dns_zone:
-    description: "Flag for external DNS zone management"
-    type: bool
-    default: false
-
-  imported_cert_secret_name:
-    description: "AWS Secrets Manager secret name for imported certificate"
-    type: string
-    default: ""
-
-  internal_ca_arn:
-    description: "ARN of Private Certificate Authority for internal certificates"
-    type: string
-    default: ""
-
-  early_renewal_days:
-    description: "Number of days before certificate expiry to trigger renewal"
-    type: number
-    default: 0
-
-  options:
-    description: "Certificate configuration options"
-    type: map
-    default: {}
-    fields:
-      certificate_transparency:
-        description: "Enable/disable certificate transparency logging"
-        type: bool
-      exportable:
-        description: "Enable/disable certificate export capability"
-        type: bool
+  # 4. Apply
+  terragrunt apply
   ```
 
-  Terragrunt Configuration:
+  ### Generated `inputs.yaml`
+
+  After scaffolding, Terragrunt generates an `inputs.yaml` file with the module-specific
+  inputs below:
+
+  ```yaml
+  #name: ""                    # (Optional) Explicit ACM resource name. Overrides name_prefix when set. Default: ""
+  #name_prefix: "managed-cert" # (Optional) Prefix used when name is empty. Default: "managed-cert"
+  #create: true                 # (Optional) Set to false to skip all ACM and Route53 resources. Default: true
+
+  certificate_type: "external" # (Optional) Certificate mode. Valid values: "external", "internal", "imported". Default: "external"
+  domain_zone: "example.com"   # (Required for external/internal) Primary DNS zone used for the certificate. Example: "example.com"
+  #domain_alias: "app"         # (Optional) Host label prepended to domain_zone. Example: "app" -> "app.example.com". Default: ""
+  #domain_alternates:           # (Optional) Subject Alternative Names (SANs) for the certificate. Default: []
+  #  - "*.example.com"
+  #additional_domain_zones:     # (Optional) Extra Route53 zones used to validate SANs outside domain_zone. Default: []
+  #  - "example.net"
+
+  # Cross-account Route53 validation.
+  #cross_account:
+  #  enabled: false             # (Optional) Enable Route53 lookups/records in another AWS account. Default: false
+  #  alias: "cross_account"    # (Optional) AWS provider alias generated in terragrunt.hcl. Default: "cross_account"
+  #  region: "us-east-1"       # (Optional) Region for the cross-account AWS provider. Defaults to global-inputs.yaml default.region.
+  #  sts_role_arn: "arn:aws:iam::111122223333:role/TerragruntCrossAccountRole" # (Optional) Role assumed for cross-account Route53 access.
+
+  #private_zone: false          # (Optional) Set true when the validation zone is a private Route53 hosted zone. Default: false
+  #external_dns_zone: false     # (Optional) Set true when DNS validation records are managed outside Route53. Default: false
+
+  #imported_cert_secret_name: "" # (Required when certificate_type = "imported") Secrets Manager secret containing base64-encoded keys: key, public_key, cert_chain. Default: ""
+  #internal_ca_arn: ""           # (Required when certificate_type = "internal") AWS Private CA ARN used to issue the certificate. Default: ""
+  #early_renewal_days: 30         # (Optional) Days before expiry to renew internal certificates. Only used for internal certificates. Default: 0
+
+  #options:                     # (Optional) ACM certificate options. Default: {}
+  #  certificate_transparency: true # (Optional) Enable certificate transparency logging for eligible public certificates. Default: unset/provider default
+  #  exportable: false             # (Optional) Make the certificate exportable when ACM supports it. Default: unset/provider default
+
+  #alerts:                      # (Optional) Optional alert settings exposed by the module interface. Default: {}
+  #  enabled: false             # (Optional) Enable alert metadata. Default: false
+  #  priority: 3                # (Optional) Alert priority/severity. Default: 3
+  #  sns_topic_arn: ""         # (Optional) SNS topic ARN recorded in the alert settings. Default: ""
+  ```
+
+  ### Generated `terragrunt.hcl`
+
+  The scaffold also renders a `terragrunt.hcl` that loads `inputs.yaml`, derives the
+  cross-account provider settings, and maps the file into module inputs:
+
   ```hcl
-  include {
-    path = find_in_parent_folders()
+  locals {
+    local_vars  = yamldecode(file("./inputs.yaml"))
+    spoke_vars  = yamldecode(file(find_in_parent_folders("spoke-inputs.yaml")))
+    region_vars = yamldecode(file(find_in_parent_folders("region-inputs.yaml")))
+    env_vars    = yamldecode(file(find_in_parent_folders("env-inputs.yaml")))
+    global_vars = yamldecode(file(find_in_parent_folders("global-inputs.yaml")))
+
+    local_tags  = jsondecode(file("./local-tags.json"))
+    spoke_tags  = jsondecode(file(find_in_parent_folders("spoke-tags.json")))
+    region_tags = jsondecode(file(find_in_parent_folders("region-tags.json")))
+    env_tags    = jsondecode(file(find_in_parent_folders("env-tags.json")))
+    global_tags = jsondecode(file(find_in_parent_folders("global-tags.json")))
+
+    cross_account              = try(local.local_vars.cross_account.enabled, false)
+    cross_account_alias        = try(local.local_vars.cross_account.alias, "cross_account")
+    cross_account_region       = try(local.local_vars.cross_account.region, local.global_vars.default.region)
+    cross_account_sts_role_arn = try(local.local_vars.cross_account.sts_role_arn, local.global_vars.default.sts_role_arn)
+
+    tags = merge(
+      local.global_tags,
+      local.env_tags,
+      local.region_tags,
+      local.spoke_tags,
+      local.local_tags
+    )
+  }
+
+  include "root" {
+    path = find_in_parent_folders("root.hcl")
+  }
+
+  generate "provider_l" {
+    path        = "provider.l.tf"
+    if_exists   = "overwrite_terragrunt"
+    if_disabled = "remove_terragrunt"
+    contents    = <<EOF_PROVIDER
+  provider "aws" {
+    alias  = "${local.cross_account_alias}"
+    region = "${local.cross_account_region}"
+
+    assume_role {
+      role_arn     = "${local.cross_account_sts_role_arn}"
+      session_name = "terragrunt"
+    }
+  }
+  EOF_PROVIDER
   }
 
   terraform {
-    source = "git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git?ref=v1.0.0"
-  }
-  
-  
-  # Generate global cross_account provider block
-  generate "provider_l" {
-    path = "provider.l.tf"
-    #   disable     = !local.cross_account
-    if_exists   = "overwrite_terragrunt"
-    if_disabled = "remove_terragrunt"
-    contents    = <<EOF
-    provider "aws" {
-      alias = "${local.cross_account_alias}"
-      region = "${local.cross_account_region}"
-      assume_role {
-        role_arn     = "${local.cross_account_sts_role_arn}"
-        session_name = "terragrunt"
-      }
-    }
-    EOF
+    source = "git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git?ref=v1.3.5"
   }
 
   inputs = {
-    certificate_type = "external"
-    domain_zone     = "example.com"
-    domain_alias    = "app"
-    domain_alternates = ["*.app.example.com"]
+    is_hub    = false
+    org       = local.env_vars.org
+    spoke_def = local.spoke_vars.spoke
 
-    options = {
-      certificate_transparency = true
-      exportable = false
-    }
+    certificate_type        = local.local_vars.certificate_type
+    domain_zone             = local.local_vars.domain_zone
+    domain_alias            = try(local.local_vars.domain_alias, "")
+    domain_alternates       = try(local.local_vars.domain_alternates, [])
+    additional_domain_zones = try(local.local_vars.additional_domain_zones, [])
+    create                  = try(local.local_vars.create, true)
+    external_dns_zone       = try(local.local_vars.external_dns_zone, false)
+    imported_cert_secret_name = try(local.local_vars.imported_cert_secret_name, "")
+    internal_ca_arn         = try(local.local_vars.internal_ca_arn, "")
+    early_renewal_days      = try(local.local_vars.early_renewal_days, 0)
+    name                    = try(local.local_vars.name, "")
+    name_prefix             = try(local.local_vars.name_prefix, "managed-cert")
+    options                 = try(local.local_vars.options, {})
+    alerts                  = try(local.local_vars.alerts, {})
+    private_zone            = try(local.local_vars.private_zone, false)
+
+    cross_account = local.cross_account
+    extra_tags    = local.tags
   }
   ```
 
-# Example usage
 examples: |-
-  External Certificate with Local DNS Validation:
-  ```hcl
-  module "external_certificate" {
-    source = "cloudopsworks/terraform-module-aws-acm-certificate"
+  ### External certificate with Route53 validation
 
-    certificate_type = "external"
-    domain_zone     = "example.com"
-    domain_alias    = "api"
-    domain_alternates = ["*.api.example.com"]
-    cross_account   = false
-    external_dns_zone = false
-
-    options = {
-      certificate_transparency = true
-      exportable = false
-    }
-  }
+  ```yaml
+  certificate_type: "external"
+  domain_zone: "example.com"
+  domain_alias: "app"
+  domain_alternates:
+    - "*.app.example.com"
+  options:
+    certificate_transparency: true
+    exportable: false
   ```
 
-  Cross-Account Certificate:
-  ```hcl
-  module "cross_account_cert" {
-    source = "cloudopsworks/terraform-module-aws-acm-certificate"
-    providers = {
-      aws.cross_account = aws.dns_account
-    }
+  ### Cross-account Route53 validation
 
-    certificate_type = "external"
-    domain_zone     = "example.com"
-    domain_alias    = "app"
-    cross_account   = true
-    domain_alternates = ["api.example.com"]
-
-    options = {
-      certificate_transparency = true
-      exportable = true
-    }
-  }
+  ```yaml
+  certificate_type: "external"
+  domain_zone: "example.com"
+  domain_alias: "api"
+  cross_account:
+    enabled: true
+    alias: "dns_account"
+    region: "us-east-1"
+    sts_role_arn: "arn:aws:iam::111122223333:role/TerragruntCrossAccountRole"
+  domain_alternates:
+    - "api.example.net"
+  additional_domain_zones:
+    - "example.net"
   ```
 
-  Imported Certificate from Secrets Manager:
-  ```hcl
-  module "imported_cert" {
-    source = "cloudopsworks/terraform-module-aws-acm-certificate"
+  ### Imported certificate from Secrets Manager
 
-    certificate_type = "imported"
-    domain_zone     = "example.com"
-    imported_cert_secret_name = "imported/wildcard-cert"
-
-    options = {
-      certificate_transparency = false
-      exportable = true
-    }
-  }
+  ```yaml
+  certificate_type: "imported"
+  domain_zone: "example.com"
+  imported_cert_secret_name: "/platform/shared/acm/wildcard-example-com"
+  options:
+    exportable: true
   ```
 
-  Internal Certificate with Private CA:
-  ```hcl
-  module "internal_cert" {
-    source = "cloudopsworks/terraform-module-aws-acm-certificate"
+  ### Internal certificate from AWS Private CA
 
-    certificate_type = "internal"
-    domain_zone     = "internal.example.com"
-    domain_alias    = "service"
-    internal_ca_arn = "arn:aws:acm-pca:region:account:certificate-authority/12345678-1234-1234-1234-123456789012"
-    early_renewal_days = 30
-
-    options = {
-      certificate_transparency = false
-      exportable = true
-    }
-  }
+  ```yaml
+  certificate_type: "internal"
+  domain_zone: "internal.example.com"
+  domain_alias: "service"
+  internal_ca_arn: "arn:aws:acm-pca:us-east-1:111122223333:certificate-authority/12345678-1234-1234-1234-123456789012"
+  early_renewal_days: 30
+  options:
+    exportable: true
   ```
 
-# How to get started quickly
 quickstart: |-
-  1. Create a Terragrunt configuration file (terragrunt.hcl):
-     ```hcl
-     include {
-       path = find_in_parent_folders()
-     }
-
-     terraform {
-       source = "git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git?ref=v1.0.0"
-     }
-
-     inputs = {
-       certificate_type = "external"
-       domain_zone     = "example.com"
-       domain_alias    = "app"
-       domain_alternates = ["*.app.example.com"]
-
-       options = {
-         certificate_transparency = true
-         exportable = false
-       }
-     }
+  1. Create a Terragrunt deployment directory and scaffold the module:
+     ```sh
+     mkdir -p prod/us-east-1/spoke-001/acm-certificate
+     cd prod/us-east-1/spoke-001/acm-certificate
+     terragrunt scaffold github.com/cloudopsworks/terraform-module-aws-acm-certificate
      ```
 
-  2. For cross-account setup, configure the provider (provider.tf):
-     ```hcl
-     provider "aws" {
-       alias = "cross_account"
-       assume_role {
-         role_arn = "arn:aws:iam::ACCOUNT_ID:role/CrossAccountRole"
-       }
-     }
-     ```
+  2. Edit `inputs.yaml` for your certificate type:
+     - Set `certificate_type` to `external`, `imported`, or `internal`
+     - Set `domain_zone` and optional `domain_alias` / `domain_alternates`
+     - For `imported`, set `imported_cert_secret_name`
+     - For `internal`, set `internal_ca_arn` and optional `early_renewal_days`
+     - For cross-account DNS validation, define the `cross_account` object
 
-  3. Initialize Terragrunt:
-     ```bash
-     terragrunt init
-     ```
-
-  4. Review the planned changes:
-     ```bash
+  3. Review the plan:
+     ```sh
      terragrunt plan
      ```
 
-  5. Apply the configuration:
-     ```bash
+  4. Apply the configuration:
+     ```sh
      terragrunt apply
      ```
 
-  6. Monitor certificate status:
-     - For external certificates: Check Route53 for validation records
-     - For imported certificates: Verify secret in Secrets Manager
-     - For internal certificates: Monitor Private CA for issuance
+  5. Monitor validation/issuance:
+     - External certificates: ensure DNS validation records propagate
+     - Imported certificates: verify the Secrets Manager payload contains `key`, `public_key`, and `cert_chain`
+     - Internal certificates: verify the referenced Private CA is active and authorized
 
 include:
   - "docs/targets.md"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,8 +9,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.43.0 |
-| <a name="provider_aws.cross_account"></a> [aws.cross\_account](#provider\_aws.cross\_account) | 6.43.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
+| <a name="provider_aws.cross_account"></a> [aws.cross\_account](#provider\_aws.cross\_account) | ~> 6.35 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,8 +9,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
-| <a name="provider_aws.cross_account"></a> [aws.cross\_account](#provider\_aws.cross\_account) | ~> 6.35 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.43.0 |
+| <a name="provider_aws.cross_account"></a> [aws.cross\_account](#provider\_aws.cross\_account) | 6.43.0 |
 
 ## Modules
 
@@ -67,8 +67,8 @@
 
 | Name | Description |
 |------|-------------|
-| <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | n/a |
-| <a name="output_acm_certificate_expire_date"></a> [acm\_certificate\_expire\_date](#output\_acm\_certificate\_expire\_date) | n/a |
-| <a name="output_acm_certificate_renewal_elegibility"></a> [acm\_certificate\_renewal\_elegibility](#output\_acm\_certificate\_renewal\_elegibility) | n/a |
-| <a name="output_acm_certificate_status"></a> [acm\_certificate\_status](#output\_acm\_certificate\_status) | n/a |
-| <a name="output_acm_certificate_validation_options"></a> [acm\_certificate\_validation\_options](#output\_acm\_certificate\_validation\_options) | n/a |
+| <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | ARN of the ACM certificate created or imported by this module. |
+| <a name="output_acm_certificate_expire_date"></a> [acm\_certificate\_expire\_date](#output\_acm\_certificate\_expire\_date) | Certificate expiration timestamp reported by ACM. |
+| <a name="output_acm_certificate_renewal_elegibility"></a> [acm\_certificate\_renewal\_elegibility](#output\_acm\_certificate\_renewal\_elegibility) | ACM renewal eligibility state for the managed certificate. |
+| <a name="output_acm_certificate_status"></a> [acm\_certificate\_status](#output\_acm\_certificate\_status) | Current ACM certificate status returned by AWS. |
+| <a name="output_acm_certificate_validation_options"></a> [acm\_certificate\_validation\_options](#output\_acm\_certificate\_validation\_options) | Domain validation records to publish when using external DNS automation for public certificates. |

--- a/output.tf
+++ b/output.tf
@@ -8,6 +8,7 @@
 #
 
 output "acm_certificate_arn" {
+  description = "ARN of the ACM certificate created or imported by this module."
   value = try(aws_acm_certificate_validation.cross_cert_validation[0].certificate_arn,
     aws_acm_certificate_validation.local_cert_validation[0].certificate_arn,
     aws_acm_certificate.imported[0].arn,
@@ -18,10 +19,12 @@ output "acm_certificate_arn" {
 }
 
 output "acm_certificate_validation_options" {
-  value = var.create && var.external_dns_zone == true && var.certificate_type == "external" ? aws_acm_certificate.this[0].domain_validation_options : null
+  description = "Domain validation records to publish when using external DNS automation for public certificates."
+  value       = var.create && var.external_dns_zone == true && var.certificate_type == "external" ? aws_acm_certificate.this[0].domain_validation_options : null
 }
 
 output "acm_certificate_status" {
+  description = "Current ACM certificate status returned by AWS."
   value = try(aws_acm_certificate.this[0].status,
     aws_acm_certificate.imported[0].status,
     aws_acm_certificate.internal[0].status,
@@ -30,6 +33,7 @@ output "acm_certificate_status" {
 }
 
 output "acm_certificate_renewal_elegibility" {
+  description = "ACM renewal eligibility state for the managed certificate."
   value = try(aws_acm_certificate.this[0].renewal_eligibility,
     aws_acm_certificate.imported[0].renewal_eligibility,
     aws_acm_certificate.internal[0].renewal_eligibility,
@@ -38,6 +42,7 @@ output "acm_certificate_renewal_elegibility" {
 }
 
 output "acm_certificate_expire_date" {
+  description = "Certificate expiration timestamp reported by ACM."
   value = try(aws_acm_certificate.this[0].not_after,
     aws_acm_certificate.imported[0].not_after,
     aws_acm_certificate.internal[0].not_after,


### PR DESCRIPTION
## Summary

- restore the ACM module boilerplate inputs template with deployment-ready YAML comments
- fix the scaffolded terragrunt.hcl cross-account mapping so the module still receives the expected boolean flag
- regenerate README/terraform docs and add output descriptions so generated documentation is complete

+semver: patch